### PR TITLE
Fix: homebrew don't support option in homebrew-core anymore

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -31,7 +31,7 @@ We recommend installing Rust through [rustup](https://www.rustup.rs/). If you do
     
     `clang` comes with Xcode command line tools, and can also be installed with homebrew:
     
-        $ brew install --with-clang llvm    
+        $ brew install llvm    
 
 * Windows:
 


### PR DESCRIPTION
----
https://stackoverflow.com/questions/57788632/homebrew-error-invalid-option-with-clang

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-doc/6)
<!-- Reviewable:end -->
